### PR TITLE
database-mismatch-solution

### DIFF
--- a/src/main/java/org/dependencytrack/model/Severity.java
+++ b/src/main/java/org/dependencytrack/model/Severity.java
@@ -48,25 +48,4 @@ public enum Severity {
         return Arrays.stream(values()).filter(value -> value.level == level).findFirst().orElse(UNASSIGNED);
     }
 
-    public String getSeverityAsString(){
-        if(level == 0){
-            return "UNASSIGNED";
-        }
-        if(level == 1){
-            return "INFO";
-        }
-        if(level == 2){
-            return "LOW";
-        }
-        if(level == 3){
-            return "MEDIUM";
-        }
-        if(level == 4){
-            return "HIGH";
-        }
-        if(level == 5){
-            return "CRITICAL";
-        }
-        return null;
-    }
 }

--- a/src/main/java/org/dependencytrack/model/Severity.java
+++ b/src/main/java/org/dependencytrack/model/Severity.java
@@ -47,4 +47,26 @@ public enum Severity {
     public static Severity getSeverityByLevel(final int level){
         return Arrays.stream(values()).filter(value -> value.level == level).findFirst().orElse(UNASSIGNED);
     }
+
+    public String getSeverityAsString(){
+        if(level == 0){
+            return "UNASSIGNED";
+        }
+        if(level == 1){
+            return "INFO";
+        }
+        if(level == 2){
+            return "LOW";
+        }
+        if(level == 3){
+            return "MEDIUM";
+        }
+        if(level == 4){
+            return "HIGH";
+        }
+        if(level == 5){
+            return "CRITICAL";
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -72,6 +72,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @return a new vulnerability object
      */
     public Vulnerability createVulnerability(Vulnerability vulnerability, boolean commitIndex) {
+        vulnerability.setSeverity(vulnerability.getSeverity());
         final Vulnerability result = persist(vulnerability);
         Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, pm.detachCopy(result)));
         commitSearchIndex(commitIndex, Vulnerability.class);

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -72,6 +72,8 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @return a new vulnerability object
      */
     public Vulnerability createVulnerability(Vulnerability vulnerability, boolean commitIndex) {
+        // the following line calculates the severity of the vulnerability to make sure that the severity field
+        // is not null in the database when creating a vulnerability
         vulnerability.setSeverity(vulnerability.getSeverity());
         final Vulnerability result = persist(vulnerability);
         Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, pm.detachCopy(result)));

--- a/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
+++ b/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
@@ -37,6 +37,7 @@ class UpgradeItems {
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v470.v470Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v480.v480Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v490.v490Updater.class);
+        UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v4100.v4100Updater.class);
     }
 
     static List<Class<? extends UpgradeItem>> getUpgradeItems() {

--- a/src/main/java/org/dependencytrack/upgrade/v4100/v4100Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4100/v4100Updater.java
@@ -48,20 +48,20 @@ public class v4100Updater extends AbstractUpgradeItem {
         LOGGER.info("Updating all null severities from database");
         try (final Statement stmt = connection.createStatement()) {
             final ResultSet rs = stmt.executeQuery("""
-                    SELECT *
+                    SELECT CVSSV2BASESCORE, CVSSV3BASESCORE, OWASPRRLIKELIHOODSCORE, OWASPRRTECHNICALIMPACTSCORE, OWASPRRBUSINESSIMPACTSCORE, VULNID
                     FROM "VULNERABILITY"
                     WHERE "SEVERITY" is NULL
                     """);
             while(rs.next()){
-                String vulnID = rs.getString(32);
+                String vulnID = rs.getString(6);
                 Severity severity = VulnerabilityUtil.getSeverity(
-                    rs.getBigDecimal(4),
-                    rs.getBigDecimal(8),
-                    rs.getBigDecimal(19),
-                    rs.getBigDecimal(18), 
-                    rs.getBigDecimal(20)
+                    rs.getBigDecimal(1),
+                    rs.getBigDecimal(2),
+                    rs.getBigDecimal(3),
+                    rs.getBigDecimal(4), 
+                    rs.getBigDecimal(5)
                     );
-                final String severityString = severity.getSeverityAsString();
+                final String severityString = severity.name();
                 final PreparedStatement ps = connection.prepareStatement("""
                         UPDATE "VULNERABILITY" SET "SEVERITY" = ? WHERE "VULNID" = ?
                         """);

--- a/src/main/java/org/dependencytrack/upgrade/v4100/v4100Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4100/v4100Updater.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+package org.dependencytrack.upgrade.v4100;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.dependencytrack.model.Severity;
+import org.dependencytrack.upgrade.v410.v410Updater;
+import org.dependencytrack.util.VulnerabilityUtil;
+
+import alpine.common.logging.Logger;
+import alpine.persistence.AlpineQueryManager;
+import alpine.server.upgrade.AbstractUpgradeItem;
+
+public class v4100Updater extends AbstractUpgradeItem {
+
+    private static final Logger LOGGER = Logger.getLogger(v410Updater.class);
+
+    @Override
+    public String getSchemaVersion() {
+        return "4.10.0";
+    }
+
+    @Override
+    public void executeUpgrade(AlpineQueryManager queryManager, Connection connection) throws Exception {
+        // Part of a fix for https://github.com/DependencyTrack/dependency-track/issues/2474
+        // recomputes all database severity values with value NULL of a vulnerability and updates them in the database
+        LOGGER.info("Updating all null severities from database");
+        try (final Statement stmt = connection.createStatement()) {
+            final ResultSet rs = stmt.executeQuery("""
+                    SELECT *
+                    FROM "VULNERABILITY"
+                    WHERE "SEVERITY" is NULL
+                    """);
+            while(rs.next()){
+                String vulnID = rs.getString(32);
+                Severity severity = VulnerabilityUtil.getSeverity(
+                    rs.getBigDecimal(4),
+                    rs.getBigDecimal(8),
+                    rs.getBigDecimal(19),
+                    rs.getBigDecimal(18), 
+                    rs.getBigDecimal(20)
+                    );
+                final String severityString = severity.getSeverityAsString();
+                final PreparedStatement ps = connection.prepareStatement("""
+                        UPDATE "VULNERABILITY" SET "SEVERITY" = ? WHERE "VULNID" = ?
+                        """);
+                
+                ps.setString(1, severityString);
+                ps.setString(2, vulnID);
+                ps.executeUpdate();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description


- The severity value of a vulnerability is now calculated before creating the vulnerability. With this change, it is impossible that the severity field of a vulnverabilty is null in the database when a vulnerability is created.
- added a upgrade script (v4100) which recomputes all database severity values with value NULL of a vulnerability and updates them in the database. This is necessary because there are existing vulnerabilities in the database which have a severity value of NULL. These vulnerabilities are not effected by the changes above and their severity values have to be recalculated separately

 
### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/2474

### Additional Details


<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
